### PR TITLE
CVW-76 move "get" methods to main BSP

### DIFF
--- a/boards/CAVeBoard-Mini/bsp_user/inc/bsp_encoder_user.h
+++ b/boards/CAVeBoard-Mini/bsp_user/inc/bsp_encoder_user.h
@@ -14,6 +14,4 @@ typedef enum
 
 extern Bsp_Encoder_t BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_MAX];
 
-Bsp_Encoder_t *BspEncoderUser_GetEncoderHandle(const Bsp_TimerHandle_t *const timer_handle);
-
 #endif /* BSP_ENCODER_USER_H */

--- a/boards/CAVeBoard-Mini/bsp_user/inc/bsp_spi_user.h
+++ b/boards/CAVeBoard-Mini/bsp_user/inc/bsp_spi_user.h
@@ -11,6 +11,4 @@ typedef enum
 
 extern Bsp_Spi_t BspSpiUser_HandleTable[BSP_SPI_USER_MAX];
 
-Bsp_Spi_t *BspSpiUser_GetSpi(const Bsp_SpiHandle_t *const spi_handle);
-
 #endif /* BSP_SPI_USER_H */

--- a/boards/CAVeBoard-Mini/bsp_user/inc/bsp_timer_user.h
+++ b/boards/CAVeBoard-Mini/bsp_user/inc/bsp_timer_user.h
@@ -11,6 +11,4 @@ typedef enum
 
 extern Bsp_Timer_t BspTimerUser_HandleTable[BSP_TIMER_USER_TIMER_MAX];
 
-Bsp_Timer_t *BspTimerUser_GetTimer(const Bsp_TimerHandle_t *const timer_handle);
-
 #endif /* BSP_TIMER_USER_H */

--- a/boards/CAVeBoard-Mini/bsp_user/inc/bsp_uart_user.h
+++ b/boards/CAVeBoard-Mini/bsp_user/inc/bsp_uart_user.h
@@ -12,6 +12,4 @@ typedef enum
 
 extern Bsp_Uart_t BspUartUser_HandleTable[BSP_UART_USER_MAX];
 
-Bsp_Uart_t *BspUartUser_GetUart(const Bsp_UartHandle_t *const uart_handle);
-
 #endif /* BSP_UART_USER_H */

--- a/boards/CAVeBoard-Mini/bsp_user/src/bsp_encoder_user.c
+++ b/boards/CAVeBoard-Mini/bsp_user/src/bsp_encoder_user.c
@@ -66,27 +66,3 @@ Bsp_Encoder_t BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_MAX] = {
         .angular_rate             = 0,
     },
 };
-
-Bsp_Encoder_t *BspEncoderUser_GetEncoderHandle(const Bsp_TimerHandle_t *const timer_handle)
-{
-    Bsp_Encoder_t *encoder_handle = NULL;
-
-    if (timer_handle == BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_0].timer_handle)
-    {
-        encoder_handle = &BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_0];
-    }
-    else if (timer_handle == BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_1].timer_handle)
-    {
-        encoder_handle = &BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_1];
-    }
-    else if (timer_handle == BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_2].timer_handle)
-    {
-        encoder_handle = &BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_2];
-    }
-    else if (timer_handle == BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_3].timer_handle)
-    {
-        encoder_handle = &BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_3];
-    }
-
-    return encoder_handle;
-}

--- a/boards/CAVeBoard-Mini/bsp_user/src/bsp_spi_user.c
+++ b/boards/CAVeBoard-Mini/bsp_user/src/bsp_spi_user.c
@@ -16,19 +16,3 @@ Bsp_Spi_t BspSpiUser_HandleTable[BSP_SPI_USER_MAX] = {
         },
     },
 };
-
-Bsp_Spi_t *BspSpiUser_GetSpi(const Bsp_SpiHandle_t *const spi_handle)
-{
-    Bsp_Spi_t *spi = NULL;
-
-    /* TODO CVW-76 duplicate this pattern to the rest of the BSP User "get" methods */
-    for (BspSpiUser_Spi_t user_spi = BSP_SPI_USER_0; user_spi < BSP_SPI_USER_MAX; user_spi++)
-    {
-        if (spi_handle == BspSpiUser_HandleTable[user_spi].spi_handle)
-        {
-            spi = &BspSpiUser_HandleTable[user_spi];
-        }
-    }
-
-    return spi;
-}

--- a/boards/CAVeBoard-Mini/bsp_user/src/bsp_timer_user.c
+++ b/boards/CAVeBoard-Mini/bsp_user/src/bsp_timer_user.c
@@ -18,15 +18,3 @@ Bsp_Timer_t BspTimerUser_HandleTable[BSP_TIMER_USER_TIMER_MAX] = {
         .counts = 0U,
     },
 };
-
-Bsp_Timer_t *BspTimerUser_GetTimer(const Bsp_TimerHandle_t *const timer_handle)
-{
-    Bsp_Timer_t *timer = NULL;
-
-    if (timer_handle == BspTimerUser_HandleTable[BSP_TIMER_USER_TIMER_0].timer_handle)
-    {
-        timer = &BspTimerUser_HandleTable[BSP_TIMER_USER_TIMER_0];
-    }
-
-    return timer;
-}

--- a/boards/CAVeBoard-Mini/bsp_user/src/bsp_uart_user.c
+++ b/boards/CAVeBoard-Mini/bsp_user/src/bsp_uart_user.c
@@ -42,18 +42,3 @@ Bsp_Uart_t BspUartUser_HandleTable[BSP_UART_USER_MAX] = {
         .read_pointer     = 0U,
     },
 };
-
-Bsp_Uart_t *BspUartUser_GetUart(const Bsp_UartHandle_t *const uart_handle)
-{
-    Bsp_Uart_t *uart = NULL;
-
-    for (BspUartUser_Uart_t user_uart = BSP_UART_USER_0; user_uart < BSP_UART_USER_MAX; user_uart++)
-    {
-        if (uart_handle == BspUartUser_HandleTable[user_uart].uart_handle)
-        {
-            uart = &BspUartUser_HandleTable[user_uart];
-        }
-    }
-
-    return uart;
-}

--- a/boards/CAVeBoard/bsp_user/inc/bsp_adc_user.h
+++ b/boards/CAVeBoard/bsp_user/inc/bsp_adc_user.h
@@ -32,6 +32,4 @@ typedef enum
 
 extern Bsp_Adc_t BspAdcUser_HandleTable[BSP_ADC_USER_ADC_MAX];
 
-Bsp_Adc_t *BspAdcUser_GetAdc(const Bsp_AdcHandle_t *const adc_handle);
-
 #endif /* BSP_ADC_USER_H */

--- a/boards/CAVeBoard/bsp_user/inc/bsp_encoder_user.h
+++ b/boards/CAVeBoard/bsp_user/inc/bsp_encoder_user.h
@@ -14,6 +14,4 @@ typedef enum
 
 extern Bsp_Encoder_t BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_MAX];
 
-Bsp_Encoder_t *BspEncoderUser_GetEncoderHandle(const Bsp_TimerHandle_t *const timer_handle);
-
 #endif /* BSP_ENCODER_USER_H */

--- a/boards/CAVeBoard/bsp_user/inc/bsp_spi_user.h
+++ b/boards/CAVeBoard/bsp_user/inc/bsp_spi_user.h
@@ -11,6 +11,4 @@ typedef enum
 
 extern Bsp_Spi_t BspSpiUser_HandleTable[BSP_SPI_USER_MAX];
 
-Bsp_Spi_t *BspSpiUser_GetSpi(const Bsp_SpiHandle_t *const spi_handle);
-
 #endif /* BSP_SPI_USER_H */

--- a/boards/CAVeBoard/bsp_user/inc/bsp_uart_user.h
+++ b/boards/CAVeBoard/bsp_user/inc/bsp_uart_user.h
@@ -12,6 +12,4 @@ typedef enum
 
 extern Bsp_Uart_t BspUartUser_HandleTable[BSP_UART_USER_MAX];
 
-Bsp_Uart_t *BspUartUser_GetUart(const Bsp_UartHandle_t *const uart_handle);
-
 #endif /* BSP_UART_USER_H */

--- a/boards/CAVeBoard/bsp_user/src/bsp_adc_user.c
+++ b/boards/CAVeBoard/bsp_user/src/bsp_adc_user.c
@@ -19,15 +19,3 @@ Bsp_Adc_t BspAdcUser_HandleTable[BSP_ADC_USER_ADC_MAX] = {
         .channels      = BSP_ADC_USER_ADC_1_CHANNELS,
     },
 };
-
-Bsp_Adc_t *BspAdcUser_GetAdc(const Bsp_AdcHandle_t *const adc_handle)
-{
-    Bsp_Adc_t *adc = NULL;
-
-    if (adc_handle == BspAdcUser_HandleTable[BSP_ADC_USER_ADC_1].adc_handle)
-    {
-        adc = &BspAdcUser_HandleTable[BSP_ADC_USER_ADC_1];
-    }
-
-    return adc;
-}

--- a/boards/CAVeBoard/bsp_user/src/bsp_encoder_user.c
+++ b/boards/CAVeBoard/bsp_user/src/bsp_encoder_user.c
@@ -66,27 +66,3 @@ Bsp_Encoder_t BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_MAX] = {
         .angular_rate             = 0,
     },
 };
-
-Bsp_Encoder_t *BspEncoderUser_GetEncoderHandle(const Bsp_TimerHandle_t *const timer_handle)
-{
-    Bsp_Encoder_t *encoder_handle = NULL;
-
-    if (timer_handle == BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_0].timer_handle)
-    {
-        encoder_handle = &BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_0];
-    }
-    else if (timer_handle == BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_1].timer_handle)
-    {
-        encoder_handle = &BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_1];
-    }
-    else if (timer_handle == BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_2].timer_handle)
-    {
-        encoder_handle = &BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_2];
-    }
-    else if (timer_handle == BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_3].timer_handle)
-    {
-        encoder_handle = &BspEncoderUser_HandleTable[BSP_ENCODER_USER_TIMER_3];
-    }
-
-    return encoder_handle;
-}

--- a/boards/CAVeBoard/bsp_user/src/bsp_spi_user.c
+++ b/boards/CAVeBoard/bsp_user/src/bsp_spi_user.c
@@ -16,19 +16,3 @@ Bsp_Spi_t BspSpiUser_HandleTable[BSP_SPI_USER_MAX] = {
         },
     },
 };
-
-Bsp_Spi_t *BspSpiUser_GetSpi(const Bsp_SpiHandle_t *const spi_handle)
-{
-    Bsp_Spi_t *spi = NULL;
-
-    /* TODO CVW-76 duplicate this pattern to the rest of the BSP User "get" methods */
-    for (BspSpiUser_Spi_t user_spi = BSP_SPI_USER_0; user_spi < BSP_SPI_USER_MAX; user_spi++)
-    {
-        if (spi_handle == BspSpiUser_HandleTable[user_spi].spi_handle)
-        {
-            spi = &BspSpiUser_HandleTable[user_spi];
-        }
-    }
-
-    return spi;
-}

--- a/boards/CAVeBoard/bsp_user/src/bsp_uart_user.c
+++ b/boards/CAVeBoard/bsp_user/src/bsp_uart_user.c
@@ -42,18 +42,3 @@ Bsp_Uart_t BspUartUser_HandleTable[BSP_UART_USER_MAX] = {
         .read_pointer     = 0U,
     },
 };
-
-Bsp_Uart_t *BspUartUser_GetUart(const Bsp_UartHandle_t *const uart_handle)
-{
-    Bsp_Uart_t *uart = NULL;
-
-    for (BspUartUser_Uart_t user_uart = BSP_UART_USER_0; user_uart < BSP_UART_USER_MAX; user_uart++)
-    {
-        if (uart_handle == BspUartUser_HandleTable[user_uart].uart_handle)
-        {
-            uart = &BspUartUser_HandleTable[user_uart];
-        }
-    }
-
-    return uart;
-}

--- a/bsp/src/bsp_adc.c
+++ b/bsp/src/bsp_adc.c
@@ -13,6 +13,7 @@
 #define BSP_ADC_MAX               (uint16_t)(1U << BSP_ADC_RESOLUTION_BITS)
 
 static void BspAdc_ConversionCompleteCallback(Bsp_AdcHandle_t *adc_handle);
+static Bsp_Adc_t *BspAdc_GetAdc(const Bsp_AdcHandle_t *const adc_handle);
 
 Bsp_Error_t BspAdc_Start(const BspAdcUser_Adc_t adc)
 {
@@ -72,7 +73,7 @@ Bsp_Error_t BspAdc_Read(const BspAdcUser_Adc_t adc, const BspAdcUser_ChannelRank
 
 static void BspAdc_ConversionCompleteCallback(Bsp_AdcHandle_t *adc_handle)
 {
-    Bsp_Adc_t *adc = BspAdcUser_GetAdc(adc_handle);
+    Bsp_Adc_t *adc = BspAdc_GetAdc(adc_handle);
 
     if (NULL != adc)
     {
@@ -81,4 +82,19 @@ static void BspAdc_ConversionCompleteCallback(Bsp_AdcHandle_t *adc_handle)
             *(adc->shadow_buffer + i) = *(adc->buffer + i); /* TODO SD-349 memcpy and average? */
         }
     }
+}
+
+static Bsp_Adc_t *BspAdc_GetAdc(const Bsp_AdcHandle_t *const adc_handle)
+{
+    Bsp_Adc_t *adc = NULL;
+
+    for (BspAdcUser_Adc_t user_adc = BSP_ADC_USER_ADC_1; user_adc < BSP_ADC_USER_ADC_MAX; user_adc++)
+    {
+        if (adc_handle == BspAdcUser_HandleTable[user_adc].adc_handle)
+        {
+            adc = &BspAdcUser_HandleTable[user_adc];
+        }
+    }
+
+    return adc;
 }

--- a/bsp/src/bsp_adc.c
+++ b/bsp/src/bsp_adc.c
@@ -93,6 +93,7 @@ static Bsp_Adc_t *BspAdc_GetAdc(const Bsp_AdcHandle_t *const adc_handle)
         if (adc_handle == BspAdcUser_HandleTable[user_adc].adc_handle)
         {
             adc = &BspAdcUser_HandleTable[user_adc];
+            break;
         }
     }
 

--- a/bsp/src/bsp_adc.c
+++ b/bsp/src/bsp_adc.c
@@ -12,7 +12,7 @@
 #define BSP_ADC_RESOLUTION_BITS   12U
 #define BSP_ADC_MAX               (uint16_t)(1U << BSP_ADC_RESOLUTION_BITS)
 
-static void BspAdc_ConversionCompleteCallback(Bsp_AdcHandle_t *adc_handle);
+static void BspAdc_ConversionCompleteCallback(const Bsp_AdcHandle_t *const adc_handle);
 static Bsp_Adc_t *BspAdc_GetAdc(const Bsp_AdcHandle_t *const adc_handle);
 
 Bsp_Error_t BspAdc_Start(const BspAdcUser_Adc_t adc)
@@ -21,7 +21,7 @@ Bsp_Error_t BspAdc_Start(const BspAdcUser_Adc_t adc)
 
     if (adc < BSP_ADC_USER_ADC_MAX)
     {
-        BspAdcUser_HandleTable[adc].adc_handle->ConvCpltCallback = BspAdc_ConversionCompleteCallback;
+        BspAdcUser_HandleTable[adc].adc_handle->ConvCpltCallback = (void (*)(Bsp_AdcHandle_t *)) BspAdc_ConversionCompleteCallback;
 
         /* DMA data width is set to half word (uint16_t), but cast buffer to uint32_t to match prototype */
         /* TODO SD-349 set large buffer to reduce interrupt frequency */
@@ -71,7 +71,7 @@ Bsp_Error_t BspAdc_Read(const BspAdcUser_Adc_t adc, const BspAdcUser_ChannelRank
     return error;
 }
 
-static void BspAdc_ConversionCompleteCallback(Bsp_AdcHandle_t *adc_handle)
+static void BspAdc_ConversionCompleteCallback(const Bsp_AdcHandle_t *const adc_handle)
 {
     Bsp_Adc_t *adc = BspAdc_GetAdc(adc_handle);
 

--- a/bsp/src/bsp_encoder.c
+++ b/bsp/src/bsp_encoder.c
@@ -14,7 +14,7 @@
 extern void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *tim_encoderHandle);
 
 static void BspEncoder_SamplePulses(Bsp_Encoder_t *const handle);
-static void BspEncoder_TimerCallback(Bsp_TimerHandle_t *handle);
+static void BspEncoder_TimerCallback(const Bsp_TimerHandle_t *const handle);
 static inline void BspEncoder_TimerCallbackHandler(Bsp_Encoder_t *const handle);
 static Bsp_Encoder_t *BspEncoder_GetEncoderHandle(const Bsp_TimerHandle_t *const timer_handle);
 
@@ -46,7 +46,7 @@ Bsp_Error_t BspEncoder_Start(const BspEncoderUser_Timer_t timer)
         }
 
         Bsp_TimerHandle_t *timer_handle = handle->timer_handle;
-        timer_handle->PeriodElapsedCallback = BspEncoder_TimerCallback;
+        timer_handle->PeriodElapsedCallback = (void (*)(Bsp_TimerHandle_t *)) BspEncoder_TimerCallback;
 
         handle->pulses_per_period        = (Bsp_EncoderPulse_t)((Bsp_EncoderPulse_t)__HAL_TIM_GET_AUTORELOAD(timer_handle) + (Bsp_EncoderPulse_t)1);
         handle->sampling                 = false;
@@ -131,7 +131,7 @@ static void BspEncoder_SamplePulses(Bsp_Encoder_t *const handle)
     }
 }
 
-static void BspEncoder_TimerCallback(Bsp_TimerHandle_t *handle)
+static void BspEncoder_TimerCallback(const Bsp_TimerHandle_t *const handle)
 {
     BspEncoder_TimerCallbackHandler(BspEncoder_GetEncoderHandle(handle));
 }

--- a/bsp/src/bsp_encoder.c
+++ b/bsp/src/bsp_encoder.c
@@ -16,6 +16,7 @@ extern void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *tim_encoderHandle);
 static void BspEncoder_SamplePulses(Bsp_Encoder_t *const handle);
 static void BspEncoder_TimerCallback(Bsp_TimerHandle_t *handle);
 static inline void BspEncoder_TimerCallbackHandler(Bsp_Encoder_t *const handle);
+static Bsp_Encoder_t *BspEncoder_GetEncoderHandle(const Bsp_TimerHandle_t *const timer_handle);
 
 Bsp_Error_t BspEncoder_Start(const BspEncoderUser_Timer_t timer)
 {
@@ -132,7 +133,7 @@ static void BspEncoder_SamplePulses(Bsp_Encoder_t *const handle)
 
 static void BspEncoder_TimerCallback(Bsp_TimerHandle_t *handle)
 {
-    BspEncoder_TimerCallbackHandler(BspEncoderUser_GetEncoderHandle(handle));
+    BspEncoder_TimerCallbackHandler(BspEncoder_GetEncoderHandle(handle));
 }
 
 static inline void BspEncoder_TimerCallbackHandler(Bsp_Encoder_t *const handle)
@@ -154,4 +155,20 @@ static inline void BspEncoder_TimerCallbackHandler(Bsp_Encoder_t *const handle)
             handle->previous_periods_elapsed = handle->periods_elapsed;
         }
     }
+}
+
+static Bsp_Encoder_t *BspEncoder_GetEncoderHandle(const Bsp_TimerHandle_t *const timer_handle)
+{
+    Bsp_Encoder_t *encoder_handle = NULL;
+
+    for (BspEncoderUser_Timer_t user_timer = BSP_ENCODER_USER_TIMER_0; user_timer < BSP_ENCODER_USER_TIMER_MAX; user_timer++)
+    {
+        if (timer_handle == BspEncoderUser_HandleTable[user_timer].timer_handle)
+        {
+            encoder_handle = &BspEncoderUser_HandleTable[user_timer];
+            break;
+        }
+    }
+
+    return encoder_handle;
 }

--- a/bsp/src/bsp_spi.c
+++ b/bsp/src/bsp_spi.c
@@ -124,6 +124,7 @@ static Bsp_Spi_t *BspSpi_GetSpi(const Bsp_SpiHandle_t *const spi_handle)
         if (spi_handle == BspSpiUser_HandleTable[user_spi].spi_handle)
         {
             spi = &BspSpiUser_HandleTable[user_spi];
+            break;
         }
     }
 

--- a/bsp/src/bsp_spi.c
+++ b/bsp/src/bsp_spi.c
@@ -11,7 +11,7 @@
 
 extern void HAL_SPI_MspInit(SPI_HandleTypeDef *spiHandle);
 
-static void BspSpi_Callback(Bsp_SpiHandle_t *spi_handle);
+static void BspSpi_Callback(const Bsp_SpiHandle_t *const spi_handle);
 static Bsp_Spi_t *BspSpi_GetSpi(const Bsp_SpiHandle_t *const spi_handle);
 
 Bsp_Error_t BspSpi_Start(const BspSpiUser_Spi_t spi)
@@ -20,8 +20,8 @@ Bsp_Error_t BspSpi_Start(const BspSpiUser_Spi_t spi)
 
     if (spi < BSP_SPI_USER_MAX)
     {
-        BspSpiUser_HandleTable[spi].spi_handle->TxCpltCallback = BspSpi_Callback;
-        BspSpiUser_HandleTable[spi].spi_handle->RxCpltCallback = BspSpi_Callback;
+        BspSpiUser_HandleTable[spi].spi_handle->TxCpltCallback = (void (*)(Bsp_SpiHandle_t *)) BspSpi_Callback;
+        BspSpiUser_HandleTable[spi].spi_handle->RxCpltCallback = (void (*)(Bsp_SpiHandle_t *)) BspSpi_Callback;
         BspSpiUser_HandleTable[spi].busy                       = false;
         BspSpiUser_HandleTable[spi].callback.function          = NULL;
         BspSpiUser_HandleTable[spi].callback.arg               = NULL;
@@ -100,7 +100,7 @@ Bsp_Error_t BspSpi_Receive(const BspSpiUser_Spi_t spi, uint8_t *const data, cons
     return error;
 }
 
-static void BspSpi_Callback(Bsp_SpiHandle_t *spi_handle)
+static void BspSpi_Callback(const Bsp_SpiHandle_t *const spi_handle)
 {
     Bsp_Spi_t *spi = BspSpi_GetSpi(spi_handle);
 

--- a/bsp/src/bsp_spi.c
+++ b/bsp/src/bsp_spi.c
@@ -12,6 +12,7 @@
 extern void HAL_SPI_MspInit(SPI_HandleTypeDef *spiHandle);
 
 static void BspSpi_Callback(Bsp_SpiHandle_t *spi_handle);
+static Bsp_Spi_t *BspSpi_GetSpi(const Bsp_SpiHandle_t *const spi_handle);
 
 Bsp_Error_t BspSpi_Start(const BspSpiUser_Spi_t spi)
 {
@@ -101,7 +102,7 @@ Bsp_Error_t BspSpi_Receive(const BspSpiUser_Spi_t spi, uint8_t *const data, cons
 
 static void BspSpi_Callback(Bsp_SpiHandle_t *spi_handle)
 {
-    Bsp_Spi_t *spi = BspSpiUser_GetSpi(spi_handle);
+    Bsp_Spi_t *spi = BspSpi_GetSpi(spi_handle);
 
     if (NULL != spi)
     {
@@ -112,4 +113,19 @@ static void BspSpi_Callback(Bsp_SpiHandle_t *spi_handle)
             spi->callback.function(spi->callback.arg);
         }
     }
+}
+
+static Bsp_Spi_t *BspSpi_GetSpi(const Bsp_SpiHandle_t *const spi_handle)
+{
+    Bsp_Spi_t *spi = NULL;
+
+    for (BspSpiUser_Spi_t user_spi = BSP_SPI_USER_0; user_spi < BSP_SPI_USER_MAX; user_spi++)
+    {
+        if (spi_handle == BspSpiUser_HandleTable[user_spi].spi_handle)
+        {
+            spi = &BspSpiUser_HandleTable[user_spi];
+        }
+    }
+
+    return spi;
 }

--- a/bsp/src/bsp_timer.c
+++ b/bsp/src/bsp_timer.c
@@ -8,6 +8,7 @@
 extern void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *tim_baseHandle);
 
 static void BspTimer_PeriodElapsedCallback(Bsp_TimerHandle_t *timer_handle);
+static Bsp_Timer_t *BspTimer_GetTimer(const Bsp_TimerHandle_t *const timer_handle);
 
 Bsp_Error_t BspTimer_Start(const BspTimerUser_Timer_t timer)
 {
@@ -97,7 +98,7 @@ Bsp_Error_t BspTimer_RegisterPeriodElapsedCallback(const BspTimerUser_Timer_t ti
 
 static void BspTimer_PeriodElapsedCallback(Bsp_TimerHandle_t *timer_handle)
 {
-    Bsp_Timer_t *timer = BspTimerUser_GetTimer(timer_handle);
+    Bsp_Timer_t *timer = BspTimer_GetTimer(timer_handle);
 
     if (NULL != timer)
     {
@@ -114,4 +115,20 @@ static void BspTimer_PeriodElapsedCallback(Bsp_TimerHandle_t *timer_handle)
             timer->period_elapsed.function(timer->period_elapsed.arg);
         }
     }
+}
+
+static Bsp_Timer_t *BspTimer_GetTimer(const Bsp_TimerHandle_t *const timer_handle)
+{
+    Bsp_Timer_t *timer = NULL;
+
+    for (BspTimerUser_Timer_t user_timer = BSP_TIMER_USER_TIMER_0; user_timer < BSP_TIMER_USER_TIMER_MAX; user_timer++)
+    {
+        if (timer_handle == BspTimerUser_HandleTable[user_timer].timer_handle)
+        {
+            timer = &BspTimerUser_HandleTable[user_timer];
+            break;
+        }
+    }
+
+    return timer;
 }

--- a/bsp/src/bsp_timer.c
+++ b/bsp/src/bsp_timer.c
@@ -7,7 +7,7 @@
 
 extern void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *tim_baseHandle);
 
-static void BspTimer_PeriodElapsedCallback(Bsp_TimerHandle_t *timer_handle);
+static void BspTimer_PeriodElapsedCallback(const Bsp_TimerHandle_t *const timer_handle);
 static Bsp_Timer_t *BspTimer_GetTimer(const Bsp_TimerHandle_t *const timer_handle);
 
 Bsp_Error_t BspTimer_Start(const BspTimerUser_Timer_t timer)
@@ -16,7 +16,7 @@ Bsp_Error_t BspTimer_Start(const BspTimerUser_Timer_t timer)
 
     if (timer < BSP_TIMER_USER_TIMER_MAX)
     {
-        BspTimerUser_HandleTable[timer].timer_handle->PeriodElapsedCallback = BspTimer_PeriodElapsedCallback;
+        BspTimerUser_HandleTable[timer].timer_handle->PeriodElapsedCallback = (void (*)(Bsp_TimerHandle_t *)) BspTimer_PeriodElapsedCallback;
 
         HAL_TIM_Base_MspInit(BspTimerUser_HandleTable[timer].timer_handle);
 
@@ -96,7 +96,7 @@ Bsp_Error_t BspTimer_RegisterPeriodElapsedCallback(const BspTimerUser_Timer_t ti
     return error;
 }
 
-static void BspTimer_PeriodElapsedCallback(Bsp_TimerHandle_t *timer_handle)
+static void BspTimer_PeriodElapsedCallback(const Bsp_TimerHandle_t *const timer_handle)
 {
     Bsp_Timer_t *timer = BspTimer_GetTimer(timer_handle);
 

--- a/bsp/src/bsp_uart.c
+++ b/bsp/src/bsp_uart.c
@@ -16,6 +16,7 @@ extern void HAL_UART_MspInit(UART_HandleTypeDef *uartHandle);
 static void BspUart_TxCallback(Bsp_UartHandle_t *uart_handle);
 static Bsp_Error_t BspUart_StartTransmit(Bsp_Uart_t *const uart);
 static void BspUart_ErrorCallback(Bsp_UartHandle_t *uart_handle);
+static Bsp_Uart_t *BspUart_GetUart(const Bsp_UartHandle_t *const uart_handle);
 
 Bsp_Error_t BspUart_Start(const BspUartUser_Uart_t uart)
 {
@@ -154,7 +155,7 @@ Bsp_Error_t BspUart_Receive(const BspUartUser_Uart_t uart, uint8_t *const data, 
 
 static void BspUart_TxCallback(Bsp_UartHandle_t *uart_handle)
 {
-    Bsp_Uart_t *uart = BspUartUser_GetUart(uart_handle);
+    Bsp_Uart_t *uart = BspUart_GetUart(uart_handle);
 
     if (NULL != uart)
     {
@@ -211,10 +212,26 @@ static Bsp_Error_t BspUart_StartTransmit(Bsp_Uart_t *const uart)
 
 static void BspUart_ErrorCallback(Bsp_UartHandle_t *uart_handle)
 {
-    const Bsp_Uart_t *const uart = BspUartUser_GetUart(uart_handle);
+    const Bsp_Uart_t *const uart = BspUart_GetUart(uart_handle);
 
     if (NULL != uart)
     {
         BSP_LOGGER_LOG_ERROR(kBspUart_LogTag, "Error detected");
     }
+}
+
+static Bsp_Uart_t *BspUart_GetUart(const Bsp_UartHandle_t *const uart_handle)
+{
+    Bsp_Uart_t *uart = NULL;
+
+    for (BspUartUser_Uart_t user_uart = BSP_UART_USER_0; user_uart < BSP_UART_USER_MAX; user_uart++)
+    {
+        if (uart_handle == BspUartUser_HandleTable[user_uart].uart_handle)
+        {
+            uart = &BspUartUser_HandleTable[user_uart];
+            break;
+        }
+    }
+
+    return uart;
 }


### PR DESCRIPTION
Move functions get BSP handles from user-defined lookup tables from HAL handles out of user BSP modules to main BSP modules.